### PR TITLE
Fix float serialization to preserve zero fraction

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
-  <php>
-    <ini name="display_errors" value="1"/>
-    <ini name="error_reporting" value="-1"/>
-  </php>
-  <testsuites>
-    <testsuite name="Project Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <ini name="error_reporting" value="-1"/>
+    </php>
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/PlaceholderProcessorRegistry/PlaceholderProcessor/JsonToUrlEncodedQueryStringProcessor.php
+++ b/src/PlaceholderProcessorRegistry/PlaceholderProcessor/JsonToUrlEncodedQueryStringProcessor.php
@@ -25,15 +25,15 @@ class JsonToUrlEncodedQueryStringProcessor extends AbstractFileBasedPlaceholderP
         }
 
         $jsonData = json_decode(trim($fileContent), true);
-        if ($jsonData === null) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             throw new WiremockContextException(
-                sprintf('Invalid JSON in file: %s', $args[0])
+                sprintf('Invalid JSON in file: %s, error: %s', $args[0], json_last_error_msg())
             );
         }
 
         foreach ($jsonData as $key => $value) {
-            if (is_array($value) || is_object($value)) {
-                $jsonData[$key] = json_encode($value);
+            if (is_float($value) || is_array($value) || is_object($value)) {
+                $jsonData[$key] = json_encode($value, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
             }
         }
 

--- a/src/WiremockContext.php
+++ b/src/WiremockContext.php
@@ -57,7 +57,7 @@ class WiremockContext implements Context
      */
     public function __construct(
         private string $baseUrl,
-        HttpClientInterface $client = null,
+        ?HttpClientInterface $client = null,
         private ?string $stubsDirectory = null,
         private array $placeholderProcessors = [],
         private bool $cleanWiremockBeforeEachScenario = false,

--- a/tests/PlaceholderProcessorRegistry/PlaceholderProcessor/JsonToUrlEncodedQueryStringProcessorTest.php
+++ b/tests/PlaceholderProcessorRegistry/PlaceholderProcessor/JsonToUrlEncodedQueryStringProcessorTest.php
@@ -385,6 +385,7 @@ class JsonToUrlEncodedQueryStringProcessorTest extends TestCase
             "string": "text",
             "integer": 42,
             "float": 3.14,
+            "float_00": 3.00,
             "boolean_true": true,
             "boolean_false": false,
             "null_value": null,
@@ -395,9 +396,7 @@ class JsonToUrlEncodedQueryStringProcessorTest extends TestCase
 
         $result = $this->processor->process($this->testStubsDirectory, [$filename, []]);
 
-        $expectedArray = rawurlencode('[1,2,3]');
-        $expectedObject = rawurlencode('{"nested":"value"}');
-        $expected = "string=text&integer=42&float=3.14&boolean_true=1&boolean_false=0&array={$expectedArray}&object={$expectedObject}";
+        $expected = "string=text&integer=42&float=3.14&float_00=3.0&boolean_true=1&boolean_false=0&array=%5B1%2C2%2C3%5D&object=%7B%22nested%22%3A%22value%22%7D";
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
The library was unexpectedly converting floats with a `.00` fractional part to integers. This PR fixes this behaviour and preserves the floats.

Additionally, PR fixes the deprecation warning because `HttpClientInterface` wasn't explicitly marked as nullable.